### PR TITLE
Update: Item Manager for Switching Cooked Objects

### DIFF
--- a/Assets/Prefabs/Cube (1).prefab
+++ b/Assets/Prefabs/Cube (1).prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2966826405390256300
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1422856880116541824}
+  - component: {fileID: 8228398913026432949}
+  - component: {fileID: 4824616353410942965}
+  - component: {fileID: 718917930871218609}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1422856880116541824
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2966826405390256300}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.00000035762787, y: 1.5799999, z: 1.9000001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8228398913026432949
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2966826405390256300}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4824616353410942965
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2966826405390256300}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: eb9cff99396e04afc8f8d579908594e1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &718917930871218609
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2966826405390256300}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Cube (1).prefab.meta
+++ b/Assets/Prefabs/Cube (1).prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b906e8c1b4baf71499f9132cbb8b9efc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Cube (2).prefab
+++ b/Assets/Prefabs/Cube (2).prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6134929539767273922
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7079979064370229396}
+  - component: {fileID: 6069024977537810003}
+  - component: {fileID: 3759604577924707248}
+  - component: {fileID: 6598820332734970534}
+  m_Layer: 0
+  m_Name: Cube (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7079979064370229396
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6134929539767273922}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.00000035762787, y: 1.5799999, z: 1.9000001}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6069024977537810003
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6134929539767273922}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3759604577924707248
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6134929539767273922}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: caf6f3d3c81307247971a0963761decc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6598820332734970534
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6134929539767273922}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Cube (2).prefab.meta
+++ b/Assets/Prefabs/Cube (2).prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99439b0051cf32c448e58411ee81e9bf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Cube.prefab
+++ b/Assets/Prefabs/Cube.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1308959961617270459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1856351134985297261}
+  - component: {fileID: 6609781503964885331}
+  - component: {fileID: 8874480175734185166}
+  - component: {fileID: 7358741271295846667}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1856351134985297261
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308959961617270459}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.58, z: 1.9}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6609781503964885331
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308959961617270459}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8874480175734185166
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308959961617270459}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 91b7f442677d81c498bbc17de72651cb, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7358741271295846667
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1308959961617270459}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Cube.prefab.meta
+++ b/Assets/Prefabs/Cube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 87d1f8e0a3803744896e3df21b037fec
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TestScene-ChangeObject.unity
+++ b/Assets/Scenes/TestScene-ChangeObject.unity
@@ -1,0 +1,26402 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &8935235
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.689999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.040001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &8935236 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 8935235}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &11211847
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (133)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -11.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &11211848 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 11211847}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &16062206
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (60)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.850006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.400002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &16062207 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 16062206}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &25147499
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (49)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.3199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5999985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.8600006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &25147500 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 25147499}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &48980932
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.970005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0499992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &48980933 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 48980932}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &52674790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 52674791}
+  m_Layer: 0
+  m_Name: Crystaline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &52674791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 52674790}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 27.656439, y: -38.086754, z: -47.29426}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 570350681}
+  - {fileID: 1506817936}
+  - {fileID: 1208260005}
+  - {fileID: 1494289151}
+  - {fileID: 1604648524}
+  - {fileID: 796382806}
+  - {fileID: 721899625}
+  - {fileID: 529736718}
+  - {fileID: 1398042351}
+  - {fileID: 1305032635}
+  - {fileID: 1721386833}
+  - {fileID: 1725258691}
+  - {fileID: 1335501631}
+  - {fileID: 1142815918}
+  - {fileID: 468936600}
+  - {fileID: 2145044361}
+  - {fileID: 521307084}
+  - {fileID: 230310254}
+  - {fileID: 182309383}
+  - {fileID: 1951571791}
+  - {fileID: 997534201}
+  - {fileID: 888566483}
+  - {fileID: 1810014817}
+  - {fileID: 1835291010}
+  - {fileID: 272886262}
+  - {fileID: 830330585}
+  - {fileID: 699791012}
+  - {fileID: 165580941}
+  - {fileID: 1974109861}
+  - {fileID: 1904031161}
+  - {fileID: 1462697129}
+  - {fileID: 458025118}
+  - {fileID: 207689294}
+  - {fileID: 528957012}
+  - {fileID: 1075941862}
+  - {fileID: 659951002}
+  - {fileID: 822369841}
+  - {fileID: 235548285}
+  - {fileID: 1615915023}
+  - {fileID: 1951158553}
+  - {fileID: 645085278}
+  - {fileID: 1824546455}
+  - {fileID: 493956913}
+  - {fileID: 1009637388}
+  - {fileID: 909089474}
+  - {fileID: 2060546603}
+  - {fileID: 1597915560}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &62733903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 62733904}
+  - component: {fileID: 62733907}
+  - component: {fileID: 62733906}
+  - component: {fileID: 62733905}
+  - component: {fileID: 62733909}
+  - component: {fileID: 62733908}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &62733904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 827100230}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &62733905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d626bc496d40e4d42bfed4606a3548cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sensX: 300
+  sensY: 300
+  orientation: {fileID: 2097481385}
+--- !u!81 &62733906
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  m_Enabled: 1
+--- !u!20 &62733907
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!45 &62733908
+Skybox:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  m_Enabled: 1
+  m_CustomSkybox: {fileID: 2100000, guid: e2341a9d03e86ec4290c72b1e22bbc7c, type: 2}
+--- !u!114 &62733909
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 62733903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!1001 &70608676
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (26)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.0700016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.670002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &70608677 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 70608676}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &72790530
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (62)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.260002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.22999573
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.459999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &72790531 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 72790530}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &75587620
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.6399994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.360001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &75587621 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 75587620}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &89425187
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (66)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.0200005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.291269
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.8100014
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &89425188 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 89425187}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &91619398
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (79)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.889999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -41.080006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &91619399 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 91619398}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &140060277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.18999958
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.889999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &140060278 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 140060277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &159423509
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (125)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.2800026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.10999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &159423510 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 159423509}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &160547572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 160547573}
+  m_Layer: 0
+  m_Name: Terrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &160547573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160547572}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.32999992, y: 5.068143, z: 17.16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1029535372}
+  - {fileID: 2088148479}
+  - {fileID: 678799511}
+  - {fileID: 662338590}
+  - {fileID: 140060278}
+  - {fileID: 791637762}
+  - {fileID: 75587621}
+  - {fileID: 70608677}
+  - {fileID: 1748630797}
+  - {fileID: 672162480}
+  - {fileID: 1827506982}
+  - {fileID: 962246489}
+  - {fileID: 1534288723}
+  - {fileID: 1557335371}
+  - {fileID: 552509840}
+  - {fileID: 585630817}
+  - {fileID: 758469201}
+  - {fileID: 466411954}
+  - {fileID: 1122504072}
+  - {fileID: 1520085256}
+  - {fileID: 812701688}
+  - {fileID: 1303550435}
+  - {fileID: 256042247}
+  - {fileID: 1749047319}
+  - {fileID: 272478284}
+  - {fileID: 8935236}
+  - {fileID: 982236622}
+  - {fileID: 440162086}
+  - {fileID: 687278668}
+  - {fileID: 1390218380}
+  - {fileID: 790755026}
+  - {fileID: 733165890}
+  - {fileID: 1844634696}
+  - {fileID: 1182236353}
+  - {fileID: 418614459}
+  - {fileID: 595373936}
+  - {fileID: 1728677094}
+  - {fileID: 1489027936}
+  - {fileID: 1374505786}
+  - {fileID: 1463971438}
+  - {fileID: 681769625}
+  - {fileID: 324226814}
+  m_Father: {fileID: 1966874631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &165580940
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (70)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -33.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.170002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 24.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &165580941 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 165580940}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &182309382
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (88)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.1399999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.650002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &182309383 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 182309382}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &184689255
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1602140354878328772, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_Name
+      value: Island1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -43.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.62
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4438744409805269867, guid: 2dd161da063824049bda8d9fb89b0af1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dd161da063824049bda8d9fb89b0af1, type: 3}
+--- !u!1001 &189888188
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (73)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.139999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -46.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &189888189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 189888188}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &207689293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.32825
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.32825002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.32825002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.904439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 39.009754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 19.806257
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.24173619
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.8529445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.44262758
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.13464823
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -17.048
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -152.349
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 120.922
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &207689294 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 207689293}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &230310253
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (87)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 32.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &230310254 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 230310253}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &235548284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.50694674
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.50694674
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5069467
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.3484383
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.723755
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 23.050259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7262673
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.11978161
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.4829681
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.47426805
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 39.205
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 49.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -47.706
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &235548285 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 235548284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &237807090
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (81)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.389999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30.619999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &237807091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 237807090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &256042246
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.1900005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &256042247 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 256042246}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &260084177
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (111)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.239998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.7300005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -32.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &260084178 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 260084177}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &272478283
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.699999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &272478284 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 272478283}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &272886261
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (92)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.170002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.869999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &272886262 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 272886261}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &300360116
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (65)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.47999573
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &300360117 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 300360116}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &306995142
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (52)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.47999573
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.090004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &306995143 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 306995142}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &324226813
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.6100006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4499999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.6800022
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &324226814 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 324226813}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &336205999
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (72)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.080002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.291269
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.380001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &336206000 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 336205999}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &336648271
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (109)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.510002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.125
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -29.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &336648272 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 336648271}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &349435503
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.670002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.25999838
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.3699999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &349435504 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 349435503}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &379535732
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.670002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.25999838
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.3699999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &379535733 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 379535732}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &380536797
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (44)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8699951
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.3300018
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &380536798 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 380536797}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &381688570
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (93)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -34.250004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &381688571 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 381688570}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &382714536
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3600044
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.6300015
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.3099993
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &382714537 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 382714536}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &398064110
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (128)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &398064111 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 398064110}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &399206860
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 399206861}
+  m_Layer: 0
+  m_Name: Outcrop
+  m_TagString: Platform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &399206861
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 399206860}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.61237246, y: 0.3535534, z: -0.3535534, w: 0.61237246}
+  m_LocalPosition: {x: 0.25, y: -10.52, z: -29.009998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1412657035}
+  - {fileID: 878071324}
+  - {fileID: 379535733}
+  - {fileID: 1267396911}
+  - {fileID: 1674603194}
+  - {fileID: 1801008731}
+  - {fileID: 1279406411}
+  - {fileID: 1507730825}
+  - {fileID: 805765321}
+  - {fileID: 1755968187}
+  - {fileID: 1719561968}
+  - {fileID: 971643716}
+  - {fileID: 398064111}
+  - {fileID: 811061716}
+  - {fileID: 1745283513}
+  - {fileID: 399975752}
+  - {fileID: 1022588737}
+  - {fileID: 11211848}
+  - {fileID: 829016294}
+  m_Father: {fileID: 987043982}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -60}
+--- !u!1001 &399975751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (131)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &399975752 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 399975751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &401537014
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.9400024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.8699994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.9199991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &401537015 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 401537014}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &418614458
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.19999695
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &418614459 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 418614458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &422604762
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (96)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -51.289997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &422604763 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 422604762}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &424220842
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1910086025429633, guid: 7c5f1376627a94cb280420efaf6d38a3, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 3439569516225702, guid: 7c5f1376627a94cb280420efaf6d38a3, type: 3}
+      propertyPath: m_Name
+      value: Bush
+      objectReference: {fileID: 0}
+    - target: {fileID: 3439569516225702, guid: 7c5f1376627a94cb280420efaf6d38a3, type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 710479135769235422, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 1505453697866213991, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 1554849618152497288, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490928917431172547, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2846781287977312370, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2892734641501784868, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 4471256743096966292, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 5067276932343521000, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5328019728081332978, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836858247209774181, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 5938499133275171363, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 8141709268102730691, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688212187970782856, guid: 7c5f1376627a94cb280420efaf6d38a3,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7c5f1376627a94cb280420efaf6d38a3, type: 3}
+--- !u!1001 &434387774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (126)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58000183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.32999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &434387775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 434387774}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &440162085
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 23.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.450001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &440162086 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 440162085}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &458025117
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.32824996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.32825002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.32825
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.421439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.049755
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.245258
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.87965614
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.110253975
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.048743166
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.46007976
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -8.576
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -10.913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 56.042
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &458025118 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 458025117}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &466406264
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (47)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.4799995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.7999954
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &466406265 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 466406264}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &466411953
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (30)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.579998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &466411954 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 466411953}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &468936599
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (82)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.5999985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.939999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &468936600 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 468936599}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &472671871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1966874631}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.297
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.42
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.21
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.20329994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.97911656
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -203.46
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      propertyPath: m_Name
+      value: Avocadian
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 472671876}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 472671875}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b8eec352fd15ec44c8ee8806a65444a7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 472671874}
+  m_SourcePrefab: {fileID: 100100000, guid: b8eec352fd15ec44c8ee8806a65444a7, type: 3}
+--- !u!4 &472671872 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: b8eec352fd15ec44c8ee8806a65444a7,
+    type: 3}
+  m_PrefabInstance: {fileID: 472671871}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &472671873 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b8eec352fd15ec44c8ee8806a65444a7,
+    type: 3}
+  m_PrefabInstance: {fileID: 472671871}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &472671874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472671873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd57d2ed40e2fc948ad569c9457fc826, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &472671875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472671873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2daa3e790577de34d8ae0ce199842370, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  is2DSprite: 0
+--- !u!136 &472671876
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472671873}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1.2
+  m_Height: 4.15
+  m_Direction: 1
+  m_Center: {x: 0, y: -1, z: 0}
+--- !u!1001 &482398104
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (115)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.239998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &482398105 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 482398104}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &493956912
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.29346508
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.29346505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.29346505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.5975609
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.311752
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.111259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.6642591
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.113886535
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.031739827
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.73809373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 11.429
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 7.383
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -263.232
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &493956913 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 493956912}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &496347689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 496347690}
+  - component: {fileID: 496347694}
+  - component: {fileID: 496347693}
+  - component: {fileID: 496347692}
+  - component: {fileID: 496347691}
+  m_Layer: 0
+  m_Name: NutPickup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &496347690
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496347689}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -12.445204, y: 7.338143, z: 24.897423}
+  m_LocalScale: {x: 2, y: 0.1, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966874631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &496347691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496347689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f6127ba4076b41c7a706e654df6f46c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OrderSource: {fileID: 1264687067}
+  activeTexture: {fileID: 2100000, guid: eb9cff99396e04afc8f8d579908594e1, type: 2}
+  inactiveTexture: {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+--- !u!136 &496347692
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496347689}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &496347693
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496347689}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &496347694
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496347689}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &521307083
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (84)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &521307084 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 521307083}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &528530796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 528530800}
+  - component: {fileID: 528530799}
+  - component: {fileID: 528530798}
+  - component: {fileID: 528530797}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &528530797
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528530796}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &528530798
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528530796}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &528530799
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528530796}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &528530800
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 528530796}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.806686, y: 2.13, z: 2.83}
+  m_LocalScale: {x: 0.19, y: 0.19, z: 0.19}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &528957011
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5739708
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.896416
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 30.341381
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9011972
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.12612225
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.072750546
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.40822074
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -16.662
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -1.684
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -48.492
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &528957012 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 528957011}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &529736717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (76)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.819998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &529736718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 529736717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &530768269
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (78)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.291269
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &530768270 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 530768269}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &549334762
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.528
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.719
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &549334763 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 549334762}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &552509839
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (28)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.940001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.379999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &552509840 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 552509839}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &558583384
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (71)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.189999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.2400017
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &558583385 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 558583384}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &568517111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (127)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &568517112 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 568517111}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &570350680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (66)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -40.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 30.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &570350681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 570350680}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &570970203
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &570970204 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 570970203}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &578039604
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (76)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.150005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &578039605 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 578039604}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &585630816
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (34)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.950001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &585630817 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 585630816}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &595373935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (40)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.230001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.240002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &595373936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 595373935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &617909027
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (99)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.4399986
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &617909028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 617909027}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &644082451
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (129)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &644082452 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 644082451}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &645085277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5069466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5069466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5069467
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.1235619
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.266754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.904259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.6368078
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.03817956
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.10590728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7627594
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 12.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -4.496
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -260.193
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &645085278 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 645085277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &656242148
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (68)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.1800003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.3500004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &656242149 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 656242148}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &659951001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.6335621
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.226753
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 30.674257
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.72316486
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.2532656
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.08995438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.6362369
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -14.586
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 27.869
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -86.32
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &659951002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 659951001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &662338589
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.7699995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &662338590 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 662338589}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &672162479
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (25)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.3100014
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.500004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &672162480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 672162479}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &678799510
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &678799511 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 678799510}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &681769624
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (38)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3399999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.5600014
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &681769625 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 681769624}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &687278667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.799999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.360004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &687278668 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 687278667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &688462434
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (95)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.700005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -20.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &688462435 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 688462434}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &691048552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 691048553}
+  m_Layer: 0
+  m_Name: Volcanic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &691048553
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 691048552}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -40.834694, y: 9.261267, z: -30.450954}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1094036567}
+  - {fileID: 987043982}
+  - {fileID: 1689264647}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &694816040
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (67)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.560001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.110001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &694816041 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 694816040}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &699791011
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (77)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &699791012 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 699791011}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &702856779
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (106)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.7300005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30.689999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &702856780 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 702856779}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &703430005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (86)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -56.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9200001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &703430006 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 703430005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &721899624
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (75)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 23.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &721899625 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 721899624}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &725451402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -37.720005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &725451403 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 725451402}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &733165889
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.4799995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &733165890 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 733165889}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &739958825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 739958826}
+  m_Layer: 0
+  m_Name: Outcrop (2)
+  m_TagString: Platform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &739958826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 739958825}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.7071068, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: 1.2299995, y: -6.68, z: -40.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2063302274}
+  - {fileID: 570970204}
+  - {fileID: 349435504}
+  - {fileID: 1529157039}
+  - {fileID: 1646739851}
+  - {fileID: 568517112}
+  - {fileID: 2092327397}
+  - {fileID: 644082452}
+  - {fileID: 1322367716}
+  - {fileID: 838700692}
+  - {fileID: 1216500155}
+  - {fileID: 382714537}
+  - {fileID: 802820399}
+  - {fileID: 1439008890}
+  - {fileID: 1959086794}
+  m_Father: {fileID: 987043982}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 180}
+--- !u!1001 &758469200
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (31)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.699999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &758469201 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 758469200}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &790755025
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5599995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.190002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &790755026 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 790755025}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &791637761
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.7299995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.37999916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &791637762 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 791637761}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &796382805
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (74)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &796382806 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 796382805}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &802820398
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2700043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6099996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &802820399 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 802820398}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &805765320
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.970005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0499992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &805765321 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 805765320}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &811061715
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (129)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &811061716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 811061715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &812701687
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (23)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.54999924
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.8899994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &812701688 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 812701687}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &822369840
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.8204384
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.304752
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 22.370258
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.69908565
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.087351754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.30535918
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.6406284
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 30.889
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 21.536
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -78.987
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &822369841 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 822369840}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &823866490
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.299999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -35.420002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &823866491 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 823866490}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &827100228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 827100230}
+  - component: {fileID: 827100229}
+  m_Layer: 0
+  m_Name: Cameraholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &827100229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827100228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72c084047559d7641b71aa1b2a90467f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraPosition: {fileID: 1871083766}
+--- !u!4 &827100230
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827100228}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 62733904}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &829016293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (134)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &829016294 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 829016293}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &830330584
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (93)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.0900006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &830330585 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 830330584}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &838700691
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.9400024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.8699994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.9199991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &838700692 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 838700691}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &861306758
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -41.440002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.849999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -68.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9700203
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.11051986
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.024501663
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.2150483
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 1774669992915916294, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_Name
+      value: Mushroom (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242809279432613771, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 3562349048943287504, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fac995a2f900942a0a74aa231bde2e6d, type: 3}
+--- !u!1001 &867800658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (110)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.210003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30.189999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &867800659 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 867800658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &878071323
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &878071324 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 878071323}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &888566482
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (86)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5800004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.340001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &888566483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 888566482}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &893321578
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (92)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -42.330006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &893321579 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 893321578}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &899371849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 899371850}
+  - component: {fileID: 899371853}
+  - component: {fileID: 899371852}
+  - component: {fileID: 899371851}
+  m_Layer: 0
+  m_Name: hex (1)
+  m_TagString: Platform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &899371850
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899371849}
+  serializedVersion: 2
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: -0.00000008940697}
+  m_LocalPosition: {x: -0.1, y: 1.06, z: -0.17}
+  m_LocalScale: {x: 80, y: 80, z: 240}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1725258691}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!64 &899371851
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899371849}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 2190622540023885545, guid: 6745d10b575a3834b9fd9c9e063c7494, type: 3}
+--- !u!23 &899371852
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899371849}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &899371853
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899371849}
+  m_Mesh: {fileID: 2190622540023885545, guid: 6745d10b575a3834b9fd9c9e063c7494, type: 3}
+--- !u!1001 &909089473
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.484438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 22.26826
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.72537434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.6883546
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 87
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199455847602543457, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyMovingCrystal (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c347f1004f927854e8b16ee3059d4fff, type: 3}
+--- !u!4 &909089474 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 909089473}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &914491935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (48)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.869999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5999985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.9799957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &914491936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 914491935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &962246488
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (33)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.620001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.019999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &962246489 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 962246488}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &971643715
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (127)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.027
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.672
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &971643716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 971643715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &982236621
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.239999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.5699997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &982236622 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 982236621}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &987043981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 987043982}
+  m_Layer: 0
+  m_Name: Moutain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &987043982
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 987043981}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 399206861}
+  - {fileID: 1548065158}
+  - {fileID: 739958826}
+  - {fileID: 1597821464}
+  - {fileID: 1461038602}
+  - {fileID: 1536120278}
+  - {fileID: 1130168825}
+  - {fileID: 1213734716}
+  - {fileID: 702856780}
+  - {fileID: 2021398225}
+  - {fileID: 260084178}
+  - {fileID: 1733345702}
+  - {fileID: 549334763}
+  - {fileID: 1952476541}
+  - {fileID: 823866491}
+  - {fileID: 725451403}
+  - {fileID: 1903476686}
+  - {fileID: 1672794453}
+  - {fileID: 482398105}
+  - {fileID: 1901426906}
+  - {fileID: 336648272}
+  - {fileID: 867800659}
+  - {fileID: 1106612651}
+  m_Father: {fileID: 691048553}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &997534200
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (85)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.66000175
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &997534201 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 997534200}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1001999281
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001999285}
+  - component: {fileID: 1001999284}
+  - component: {fileID: 1001999283}
+  - component: {fileID: 1001999282}
+  m_Layer: 6
+  m_Name: Station
+  m_TagString: Stations
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1001999282
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001999281}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1001999283
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001999281}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1001999284
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001999281}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1001999285
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001999281}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.24695423, z: -0, w: 0.96902716}
+  m_LocalPosition: {x: -4.22, y: 1.82, z: 2.55}
+  m_LocalScale: {x: 2.63, y: 0.49, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -28.595, z: 0}
+--- !u!1001 &1009637387
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 51.385998
+      objectReference: {fileID: 0}
+    - target: {fileID: 1804293788415148010, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.301476
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.989754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.255579
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.686319
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7273007
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -93.321
+      objectReference: {fileID: 0}
+    - target: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8199455847602543457, guid: c347f1004f927854e8b16ee3059d4fff,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyMovingCrystal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c347f1004f927854e8b16ee3059d4fff, type: 3}
+--- !u!4 &1009637388 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7905002295931021855, guid: c347f1004f927854e8b16ee3059d4fff,
+    type: 3}
+  m_PrefabInstance: {fileID: 1009637387}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1022588736
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (132)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -12.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1022588737 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1022588736}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1027140658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.59000015
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0499954
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.9400024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1027140659 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1027140658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1029535371
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.969999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.209999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1029535372 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1029535371}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1075941861
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.023561478
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.726753
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 31.344257
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9751733
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.12986648
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.020727724
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.1781633
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -15.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.347
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -20.753
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &1075941862 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1075941861}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1094036566
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1094036567}
+  m_Layer: 0
+  m_Name: Terrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1094036567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1094036566}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 89425188}
+  - {fileID: 2083443908}
+  - {fileID: 656242149}
+  - {fileID: 1678994751}
+  - {fileID: 694816041}
+  - {fileID: 1539314970}
+  - {fileID: 1296159106}
+  - {fileID: 893321579}
+  - {fileID: 1409604483}
+  - {fileID: 381688571}
+  - {fileID: 1828888717}
+  - {fileID: 688462435}
+  - {fileID: 703430006}
+  - {fileID: 558583385}
+  - {fileID: 336206000}
+  - {fileID: 189888189}
+  - {fileID: 530768270}
+  - {fileID: 91619399}
+  - {fileID: 1847470915}
+  - {fileID: 1719550775}
+  - {fileID: 422604763}
+  - {fileID: 237807091}
+  - {fileID: 1095316536}
+  - {fileID: 1120386773}
+  - {fileID: 1112188974}
+  - {fileID: 1836342224}
+  - {fileID: 578039605}
+  - {fileID: 617909028}
+  - {fileID: 1219295140}
+  m_Father: {fileID: 691048553}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1095316535
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (82)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1095316536 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1095316535}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1106612650
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (105)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.5200005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.82
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1106612651 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1106612650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1112188973
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (74)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.279999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -20.040005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1112188974 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1112188973}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1120386772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (83)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -33.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1120386773 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1120386772}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1120531131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1120531136}
+  - component: {fileID: 1120531135}
+  - component: {fileID: 1120531134}
+  - component: {fileID: 1120531133}
+  - component: {fileID: 1120531132}
+  m_Layer: 0
+  m_Name: BerryPickup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!114 &1120531132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120531131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f6127ba4076b41c7a706e654df6f46c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OrderSource: {fileID: 1264687067}
+  activeTexture: {fileID: 2100000, guid: eb9cff99396e04afc8f8d579908594e1, type: 2}
+  inactiveTexture: {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+--- !u!136 &1120531133
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120531131}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &1120531134
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120531131}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1120531135
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120531131}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1120531136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1120531131}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -47.39, y: 0.79, z: -12.13}
+  m_LocalScale: {x: 1.22, y: 0.061, z: 1.22}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1122504071
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (27)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.4000015
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.4799995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1122504072 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1122504071}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1127154925
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3600044
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.6300015
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.3099993
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1127154926 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1127154925}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1130168824
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (103)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -29.079998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1130168825 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1130168824}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1142445626
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1966874631}
+    m_Modifications:
+    - target: {fileID: 2320877969392964969, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_Name
+      value: Tree
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.242472
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.238143
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 26.988594
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3713040fa62684b16af4bb54d4c282ee, type: 3}
+--- !u!4 &1142445627 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8088556705994788018, guid: 3713040fa62684b16af4bb54d4c282ee,
+    type: 3}
+  m_PrefabInstance: {fileID: 1142445626}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1142815917
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (81)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.200001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.519999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1142815918 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1142815917}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1146881739
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -42.190002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -67.100006
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9547124
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.2523085
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.012655332
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.15717676
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 29.061
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 3.617
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 19.636
+      objectReference: {fileID: 0}
+    - target: {fileID: 1774669992915916294, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_Name
+      value: Mushroom (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242809279432613771, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 3562349048943287504, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fac995a2f900942a0a74aa231bde2e6d, type: 3}
+--- !u!1001 &1161802800
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (127)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1161802801 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1161802800}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1170742900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1170742901}
+  m_Layer: 0
+  m_Name: Hub
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1170742901
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1170742900}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -20.12, y: 1.34, z: -6.65}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1898984445}
+  - {fileID: 1891545662}
+  - {fileID: 306995143}
+  - {fileID: 300360117}
+  - {fileID: 1812832327}
+  - {fileID: 380536798}
+  - {fileID: 1728877707}
+  - {fileID: 466406265}
+  - {fileID: 1027140659}
+  - {fileID: 1898978427}
+  - {fileID: 25147500}
+  - {fileID: 914491936}
+  - {fileID: 2090207813}
+  - {fileID: 1629627318}
+  - {fileID: 1983393371}
+  - {fileID: 1590858137}
+  - {fileID: 1200309338}
+  - {fileID: 1996242471}
+  - {fileID: 16062207}
+  - {fileID: 1382642990}
+  - {fileID: 72790531}
+  - {fileID: 1275551506}
+  - {fileID: 1236500394}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1182236352
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.0199995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.6800022
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1182236353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1182236352}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1200309337
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (58)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -20.480003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6399994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.220001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1200309338 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1200309337}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1208260004
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (69)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1208260005 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1208260004}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1213734715
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (104)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.8199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1213734716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1213734715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1216500154
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6900024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9399996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1216500155 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1216500154}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1219295139
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (77)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.3499985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.380001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1219295140 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1219295139}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1236500393
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (64)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.130005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.37000275
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4800034
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1236500394 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1236500393}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1264687067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1264687068}
+  - component: {fileID: 1264687075}
+  - component: {fileID: 1264687074}
+  - component: {fileID: 1264687073}
+  - component: {fileID: 1264687072}
+  - component: {fileID: 1264687071}
+  - component: {fileID: 1264687070}
+  - component: {fileID: 1264687069}
+  - component: {fileID: 1264687076}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1264687068
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 0.36, y: 0.36, z: 0.36}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1871083766}
+  - {fileID: 2097481385}
+  - {fileID: 1676528654}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1264687069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 653f4d83f086c458db02cbf7c8d6e0c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentOrder: {fileID: 0}
+  orderList:
+  - {fileID: 1120531131}
+  - {fileID: 1455865040}
+  - {fileID: 496347689}
+  - {fileID: 1597915559}
+  deliveryPoint: {fileID: 1719649385}
+--- !u!114 &1264687070
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55c272b710434724aa29d037420df8b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 4
+  groundDrag: 6
+  IsMovingCheck: 0
+  jumpForce: 6
+  jumpCooldown: 0.5
+  airMultiplier: 2
+  IsJumpingCheck: 0
+  playerHeight: 0
+  whatIsGround:
+    serializedVersion: 2
+    m_Bits: 0
+  jumpKey: 32
+  SpawnPoint: {fileID: 0}
+  orientation: {fileID: 2097481385}
+--- !u!75 &1264687071
+ConstantForce:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Enabled: 1
+  m_Force: {x: 0, y: 0, z: 0}
+  m_RelativeForce: {x: 0, y: 0, z: 0}
+  m_Torque: {x: 0, y: 0, z: 0}
+  m_RelativeTorque: {x: 0, y: 0, z: 0}
+--- !u!54 &1264687072
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!136 &1264687073
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1264687074
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b3baf4aa842626a4abeef672861cae71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1264687075
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1264687076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264687067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0681a7755046cb488bf9d8f74877525, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  detectionRange: 1
+  detectionLayer:
+    serializedVersion: 2
+    m_Bits: 1
+--- !u!1001 &1267396910
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58000183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.32999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1267396911 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1267396910}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1275551505
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (63)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.9400024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.37000275
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1275551506 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1275551505}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1279406410
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3600044
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.6300015
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.3099993
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1279406411 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1279406410}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1296159105
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (91)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.779999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -26.329998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1296159106 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1296159105}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1303550434
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.8899994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1303550435 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1303550434}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1305032634
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (79)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.039998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 25.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1305032635 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1305032634}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1321355433
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6900024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9399996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1321355434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1321355433}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1322367715
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (130)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1322367716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1322367715}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1335501630
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (80)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1335501631 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1335501630}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1374505785
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (35)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.550001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.880001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1374505786 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1374505785}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1382642989
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (61)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.37000275
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.169998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1382642990 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1382642989}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1390218379
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.060001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1390218380 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1390218379}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1398042350
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (78)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 20.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1398042351 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1398042350}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1409604482
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (98)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.0200005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -52.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1409604483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1409604482}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1412657034
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.50000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1412657035 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1412657034}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1439008889
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.970005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0499992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1439008890 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1439008889}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1455865040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1455865045}
+  - component: {fileID: 1455865044}
+  - component: {fileID: 1455865043}
+  - component: {fileID: 1455865042}
+  - component: {fileID: 1455865041}
+  m_Layer: 0
+  m_Name: MushroomPickup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!114 &1455865041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455865040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f6127ba4076b41c7a706e654df6f46c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OrderSource: {fileID: 1264687067}
+  activeTexture: {fileID: 2100000, guid: eb9cff99396e04afc8f8d579908594e1, type: 2}
+  inactiveTexture: {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+--- !u!136 &1455865042
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455865040}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &1455865043
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455865040}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1455865044
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455865040}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1455865045
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1455865040}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -44.850002, y: 9.47, z: -63.960003}
+  m_LocalScale: {x: 2, y: 0.1, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1457015062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1457015063}
+  - component: {fileID: 1457015066}
+  - component: {fileID: 1457015065}
+  - component: {fileID: 1457015064}
+  m_Layer: 0
+  m_Name: hex (1)
+  m_TagString: Platform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1457015063
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457015062}
+  serializedVersion: 2
+  m_LocalRotation: {x: -1, y: -0, z: -0, w: -0.00000008940697}
+  m_LocalPosition: {x: -0.1, y: 1.06, z: -0.17}
+  m_LocalScale: {x: 80, y: 80, z: 240}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1721386833}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!64 &1457015064
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457015062}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 2190622540023885545, guid: 6745d10b575a3834b9fd9c9e063c7494, type: 3}
+--- !u!23 &1457015065
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457015062}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1457015066
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457015062}
+  m_Mesh: {fileID: 2190622540023885545, guid: 6745d10b575a3834b9fd9c9e063c7494, type: 3}
+--- !u!1001 &1461038601
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (101)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.489998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -29.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1461038602 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1461038601}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1462697128
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 51.72422
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 37.624374
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 30.42578
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.116438
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.696754
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.994259
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 919132149155446097, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+        type: 3}
+      propertyPath: m_Name
+      value: cave
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9dbaa44efa3f7fe43a52af92bdd06680, type: 3}
+--- !u!4 &1462697129 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 9dbaa44efa3f7fe43a52af92bdd06680,
+    type: 3}
+  m_PrefabInstance: {fileID: 1462697128}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1463971437
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (41)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.560001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.8899999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.0900002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1463971438 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1463971437}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1489027935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (39)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -14.470001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.8899999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.0700035
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1489027936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1489027935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1494289150
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (72)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.570004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 23.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1494289151 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1494289150}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1495052053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (117)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1495052054 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1495052053}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1500665583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1500665585}
+  - component: {fileID: 1500665584}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1500665584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1500665583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 223f9f1986c5a8046a2495fafd9cf04e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1500665585
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1500665583}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.9365554, y: -0.0006337166, z: -15.851795}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1506817935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (68)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -40.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1506817936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1506817935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1507730824
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2700043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6099996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1507730825 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1507730824}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1519200527
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1519200530}
+  - component: {fileID: 1519200529}
+  - component: {fileID: 1519200528}
+  m_Layer: 0
+  m_Name: Directional Light (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1519200528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519200527}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!108 &1519200529
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519200527}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1519200530
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519200527}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &1520085255
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (24)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0099983
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1520085256 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1520085255}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1524627429
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -41.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -66.54
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9850718
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.12968712
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.014775982
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.112234764
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1774669992915916294, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_Name
+      value: Mushroom (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242809279432613771, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 3562349048943287504, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fac995a2f900942a0a74aa231bde2e6d, type: 3}
+--- !u!1001 &1526008183
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.86
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 621042369906558455, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 965564831844150870, guid: fa11c3ef7c119f044ab464153adfd374,
+        type: 3}
+      propertyPath: m_Name
+      value: Island2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fa11c3ef7c119f044ab464153adfd374, type: 3}
+--- !u!1001 &1529157038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58000183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.32999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1529157039 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1529157038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1534288722
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (29)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -9.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1534288723 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1534288722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1536120277
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (102)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.9300003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1536120278 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1536120277}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1539314969
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (90)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -28.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.291269
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1539314970 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1539314969}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1548065157
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1548065158}
+  m_Layer: 0
+  m_Name: Outcrop (1)
+  m_TagString: Platform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1548065158
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548065157}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.35355335, y: -0.61237246, z: 0.61237246, w: 0.35355335}
+  m_LocalPosition: {x: -6.040001, y: -6.68, z: -41.74}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1629045444}
+  - {fileID: 1495052054}
+  - {fileID: 1631193399}
+  - {fileID: 2035625652}
+  - {fileID: 434387775}
+  - {fileID: 1161802801}
+  - {fileID: 2123157345}
+  - {fileID: 401537015}
+  - {fileID: 1321355434}
+  - {fileID: 1127154926}
+  - {fileID: 1652650315}
+  - {fileID: 48980933}
+  - {fileID: 159423510}
+  m_Father: {fileID: 987043982}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 120}
+--- !u!1001 &1557335370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (32)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.860001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.1899986
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1557335371 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1557335370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1590858136
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (57)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.510002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6399994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.130005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1590858137 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1590858136}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1597821463
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 490
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (100)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -35.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1597821464 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1597821463}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1597915559
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1597915560}
+  - component: {fileID: 1597915564}
+  - component: {fileID: 1597915563}
+  - component: {fileID: 1597915562}
+  - component: {fileID: 1597915561}
+  m_Layer: 0
+  m_Name: CrystalPickup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1597915560
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1597915559}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: 0.82281137, z: -0, w: 0.5683147}
+  m_LocalPosition: {x: 2.596342, y: 36.536755, z: 21.34785}
+  m_LocalScale: {x: 2, y: 0.1, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 52674791}
+  m_LocalEulerAnglesHint: {x: 0, y: 110.734, z: 0}
+--- !u!114 &1597915561
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1597915559}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f6127ba4076b41c7a706e654df6f46c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OrderSource: {fileID: 1264687067}
+  activeTexture: {fileID: 2100000, guid: eb9cff99396e04afc8f8d579908594e1, type: 2}
+  inactiveTexture: {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+--- !u!136 &1597915562
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1597915559}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &1597915563
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1597915559}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1597915564
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1597915559}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1604648523
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (73)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.759998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.110004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1604648524 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1604648523}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1615915022
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5069466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5069466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5069467
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.3084393
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.656754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 22.512259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.15659973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.21312504
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5074042
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.820119
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 64.029
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -25.809
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -174.683
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &1615915023 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1615915022}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1629045443
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.50000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1629045444 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1629045443}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1629627317
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (55)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.8399963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8100052
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25.440002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1629627318 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1629627317}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1631193398
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.670002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.25999838
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.3699999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1631193399 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1631193398}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1646739850
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (126)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58000183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.32999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1646739851 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1646739850}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1652650314
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2700043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6099996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1652650315 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1652650314}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1672794452
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (114)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.799999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -31.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1672794453 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1672794452}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1674603193
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.9400024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.8699994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.9199991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1674603194 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1674603193}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1676528652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1676528654}
+  - component: {fileID: 1676528653}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1676528653
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1676528652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf3e880fc785b244d909f661a2acdafa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemsList:
+  - itemName: Item1
+    itemPrefab: {fileID: 1001999281}
+  - itemName: Item2
+    itemPrefab: {fileID: 2966826405390256300, guid: b906e8c1b4baf71499f9132cbb8b9efc,
+      type: 3}
+  - itemName: Item3
+    itemPrefab: {fileID: 6134929539767273922, guid: 99439b0051cf32c448e58411ee81e9bf,
+      type: 3}
+  detectionRadius: 1
+  LayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!4 &1676528654
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1676528652}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2.7777774, y: 2.7777774, z: 2.7777774}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1264687068}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1678994750
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (70)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9799995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -13.259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1678994751 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1678994750}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1689264646
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 691048553}
+    m_Modifications:
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1114406053455631997, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 1371256979446794171, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_Name
+      value: Lava
+      objectReference: {fileID: 0}
+    - target: {fileID: 1371256979446794171, guid: 891b0cf6ccf704e4ca463d80279631b7,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 891b0cf6ccf704e4ca463d80279631b7, type: 3}
+--- !u!4 &1689264647 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 922367984251022915, guid: 891b0cf6ccf704e4ca463d80279631b7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1689264646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1719550774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (97)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -53.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1719550775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1719550774}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1719561967
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (126)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.421
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.352
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1719561968 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1719561967}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1719649385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1719649390}
+  - component: {fileID: 1719649389}
+  - component: {fileID: 1719649388}
+  - component: {fileID: 1719649387}
+  - component: {fileID: 1719649386}
+  - component: {fileID: 1719649391}
+  m_Layer: 0
+  m_Name: IngredientDropOff
+  m_TagString: NPC
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!114 &1719649386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac4b980003dc37f47a1149a0a6a2be1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1264687067}
+--- !u!136 &1719649387
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &1719649388
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70f68b3c7f83f43c6b9c24b7e0591093, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1719649389
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1719649390
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 6.4669995, y: 6.567143, z: 9.561001}
+  m_LocalScale: {x: 2, y: 0.1, z: 2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1966874631}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1719649391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1719649385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6f9c0723c1c63d45bda37a3070a57a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  searchType: 0
+  hasDialogue: 1
+  dialogueLines:
+  - Hello there!
+  - How have you been?
+  - Good?
+  - I'm glad to hear.
+  chatBoxPrefab: {fileID: 1961553623638865437, guid: 9a7d15e78bdd22840989e96e4f5d8328,
+    type: 3}
+--- !u!1001 &1721386832
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 240
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (94)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 27.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1457015063}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1721386833 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1721386832}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1725258690
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 240
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (95)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 15.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 899371850}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1725258691 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1725258690}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1728677093
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (36)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.790001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6299999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.939999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1728677094 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1728677093}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1728877706
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (51)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.220001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8699951
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10.760002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1728877707 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1728877706}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1733345701
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (112)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.667999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -32.197
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1733345702 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1733345701}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1745283512
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (130)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1745283513 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1745283512}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1748630796
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (22)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.630001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1748630797 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1748630796}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1749047318
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.779999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.9400005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1749047319 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1749047318}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1755968186
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (125)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.2800026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.10999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1755968187 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1755968186}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1801008730
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 399206861}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6900024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.3699992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9399996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1801008731 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1801008730}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1810014816
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (90)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.449999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1810014817 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1810014816}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1812832326
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (53)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.420002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0400009
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.980003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1812832327 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1812832326}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1824546454
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.29346502
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.29346505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.29346502
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.76956177
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.280754
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.46526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.5641658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.048236255
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.17579493
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.8052866
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 13.221
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -16.473
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -251.95099
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &1824546455 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1824546454}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1827506981
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.390001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.3100014
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1827506982 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1827506981}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1828888716
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (94)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.890003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1828888717 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1828888716}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1835291009
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (91)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1835291010 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1835291009}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1836342223
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (75)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1836342224 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1836342223}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1844634695
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8.469999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.210001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1844634696 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1844634695}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1847470914
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (80)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -48.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1847470915 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1847470914}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1871083765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1871083766}
+  m_Layer: 0
+  m_Name: CameraPos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1871083766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1871083765}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.64, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1264687068}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1885959267
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1966874631}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.6
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.502
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.11
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9486279
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.31639406
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -36.89
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -6652725513331149018, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d33fb24c131269947983e0161df4b60d, type: 2}
+    - target: {fileID: -803405088876591012, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: d33fb24c131269947983e0161df4b60d, type: 2}
+    - target: {fileID: 919132149155446097, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      propertyPath: m_Name
+      value: Food_Truck
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 78c94929ec71c484b95bced3206ed79e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1885959270}
+  m_SourcePrefab: {fileID: 100100000, guid: 78c94929ec71c484b95bced3206ed79e, type: 3}
+--- !u!4 &1885959268 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 78c94929ec71c484b95bced3206ed79e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1885959267}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1885959269 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 78c94929ec71c484b95bced3206ed79e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1885959267}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1885959270
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1885959269}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 2.118094, y: 2.1071784, z: 4.2119555}
+  m_Center: {x: -0.008010149, y: 1.0385455, z: 0.5556376}
+--- !u!1001 &1891545661
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (50)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.920002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.480003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1891545662 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1891545661}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1898978426
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (46)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.059998
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5999985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.709999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1898978427 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1898978426}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1898984444
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (43)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1898984445 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1898984444}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1901426905
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (108)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.600002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1901426906 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1901426905}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1903476685
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.139999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -36.800007
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1903476686 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1903476685}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1904031160
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (67)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -38.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 24.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1904031161 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1904031160}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1951158552
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 2887837202696231928, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_Name
+      value: DeadlyCrystal (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5069467
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.50694674
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5069467
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.0004387
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.832752
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.704258
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.15753083
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.42468777
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.40186137
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.7958215
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 30.386
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 68.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -136.659
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8638ae5aeec20774f8f5b21a8fe979d0, type: 3}
+--- !u!4 &1951158553 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7829034891004953966, guid: 8638ae5aeec20774f8f5b21a8fe979d0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1951158552}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1951571790
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (89)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 32.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1951571791 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1951571790}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1952476540
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (113)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.689999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -34.819996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1952476541 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1952476540}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1959086793
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (125)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.2800026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.10999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1959086794 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1959086793}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1966874630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1966874631}
+  m_Layer: 0
+  m_Name: HomeBiome
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1966874631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966874630}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.04, y: -5.068143, z: -8.28}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 160547573}
+  - {fileID: 1142445627}
+  - {fileID: 496347690}
+  - {fileID: 472671872}
+  - {fileID: 1885959268}
+  - {fileID: 1719649390}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1974109860
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (71)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -34.469997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.710003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 29.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1974109861 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1974109860}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1983393370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (56)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.259991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.549995
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1983393371 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1983393370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1996242470
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (59)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.7400055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5699997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.459999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &1996242471 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 1996242470}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2021398224
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 987043982}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (107)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.9300003
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -8.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -30.189999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2021398225 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2021398224}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2035625651
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.58000183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.369999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.32999992
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2035625652 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2035625651}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2060546602
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.688387
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36.469326
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.507542
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5683147
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.82281137
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 110.734
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5845780852056045792, guid: 4119fdc6025df4367bd406b26ed590c7,
+        type: 3}
+      propertyPath: m_Name
+      value: Crystal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4119fdc6025df4367bd406b26ed590c7, type: 3}
+--- !u!4 &2060546603 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4595771933866492681, guid: 4119fdc6025df4367bd406b26ed590c7,
+    type: 3}
+  m_PrefabInstance: {fileID: 2060546602}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2063302273
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (116)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.50000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.9799996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2063302274 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2063302273}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2083443907
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1094036567}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (69)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.3899994
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.049999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2083443908 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2083443907}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2088148478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 160547573}
+    m_Modifications:
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.35000038
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.5699997
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2088148479 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2088148478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2090207812
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1170742901}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (54)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: e39dc1f118682704183c73969b80b4f9, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.339996
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.22999573
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.940002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2090207813 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2090207812}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2092327396
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 739958826}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (128)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2092327397 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2092327396}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2097481384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2097481385}
+  m_Layer: 0
+  m_Name: Orientation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2097481385
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2097481384}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1264687068}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2117809852
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -41.370003
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.2699995
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -67.740005
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.99965733
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.026176924
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140370418242075726, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1774669992915916294, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_Name
+      value: Mushroom (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2090787996599730062, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242809279432613771, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    - target: {fileID: 3562349048943287504, guid: fac995a2f900942a0a74aa231bde2e6d,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 2147483647
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fac995a2f900942a0a74aa231bde2e6d, type: 3}
+--- !u!1001 &2123157344
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1548065158}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.59
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (128)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f4796f05fbc9cd549b0f977ba39b4140, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2123157345 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2123157344}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2145044360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 52674791}
+    m_Modifications:
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 5132155939732366839, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 5734083982521557223, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (83)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5781654026273230681, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7a95b6cba29f745439d8a8db3c57ea16, type: 2}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.68
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8677620091100540365, guid: 77e010e91f04744489a8413deb65d69c,
+        type: 3}
+      propertyPath: m_TagString
+      value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77e010e91f04744489a8413deb65d69c, type: 3}
+--- !u!4 &2145044361 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7756244686399170698, guid: 77e010e91f04744489a8413deb65d69c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2145044360}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1966874631}
+  - {fileID: 1170742901}
+  - {fileID: 1120531136}
+  - {fileID: 1519200530}
+  - {fileID: 1264687068}
+  - {fileID: 52674791}
+  - {fileID: 1455865045}
+  - {fileID: 827100230}
+  - {fileID: 691048553}
+  - {fileID: 1500665585}
+  - {fileID: 2117809852}
+  - {fileID: 1526008183}
+  - {fileID: 1524627429}
+  - {fileID: 184689255}
+  - {fileID: 1146881739}
+  - {fileID: 861306758}
+  - {fileID: 424220842}
+  - {fileID: 1001999285}
+  - {fileID: 528530800}

--- a/Assets/Scenes/TestScene-ChangeObject.unity.meta
+++ b/Assets/Scenes/TestScene-ChangeObject.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 69556f87276070e43ae52f2a6a9f0a7b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/ItemManager.cs
+++ b/Assets/Scripts/Managers/ItemManager.cs
@@ -1,0 +1,150 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemManager : MonoBehaviour
+{
+    // A dictionary serving as the lookup table for items
+    [System.Serializable]
+    public class ItemEntry
+    {
+        public string itemName;
+        public GameObject itemPrefab;
+    }
+
+    [SerializeField] private List<ItemEntry> itemsList = new List<ItemEntry>();
+    private Dictionary<string, GameObject> itemsLookup;
+
+    // Reference to the current item
+    private GameObject currentItem;
+
+    // Radius of the sphere collider to detect nearby objects
+    public float detectionRadius = 5f;
+
+    // Score variable
+    private int score = 0;
+
+    // Default score to be printed when an item is changed
+    private int defaultScore = 100;
+
+    // The layer mask to check only for "station" tagged objects
+    public LayerMask LayerMask;
+
+    private void Start()
+    {
+        FindInitialItem("Cube");
+        
+        //SetInitialItem("Item1", new Vector3(-0.26f, 2.11f, 2.55f));
+
+        //Invoke("SwitchtoItem2", 4f);
+
+        //Invoke("SwitchtoItem3", 8f);
+    }
+
+    private void Update()
+    {
+        // Detect if the "E" key is pressed
+        if (Input.GetKeyDown(KeyCode.E))
+        {
+            // Perform a sphere check to detect objects tagged as "station" within the radius
+            Collider[] hitColliders = Physics.OverlapSphere(transform.position, detectionRadius, LayerMask);
+            
+            foreach (var collider in hitColliders)
+            {
+                if (collider.CompareTag("Stations"))
+                {
+                    // If a "station" is detected, change the item
+                    ChangeItem("Item2");
+                    break;
+                }
+            }
+        }
+    }
+
+    private void Awake()
+    {
+        // Initialize the lookup dictionary
+        itemsLookup = new Dictionary<string, GameObject>();
+        foreach (var entry in itemsList)
+        {
+            if (!itemsLookup.ContainsKey(entry.itemName))
+            {
+                itemsLookup.Add(entry.itemName, entry.itemPrefab);
+            }
+        }
+    }
+
+    public void ChangeItem(string newItemName)
+    {
+        if (itemsLookup.TryGetValue(newItemName, out GameObject newItemPrefab))
+        {
+            Vector3 currentPosition = currentItem.transform.position;
+            Vector3 scale = currentItem.transform.localScale;
+            Quaternion rotation = Quaternion.identity;
+
+            // If there's a current item, destroy it
+            if (currentItem != null)
+            {
+                rotation = currentItem.transform.rotation;
+                Destroy(currentItem);
+            }
+
+            score = score + defaultScore;
+
+            Debug.Log($"{currentItem.name} changed to '{newItemName}'! Default score: {score}");
+
+            // Instantiate the new item at the specified position and rotation
+            currentItem = Instantiate(newItemPrefab, currentPosition, rotation);
+            currentItem.transform.localScale = scale;
+        }
+        else
+        {
+            Debug.LogError($"Item '{newItemName}' not found in the lookup table.");
+        }
+    }
+
+    public void FindInitialItem(string itemName)
+    {
+        GameObject foundItem = GameObject.Find(itemName);
+        if (foundItem != null)
+        {
+            currentItem = foundItem;
+            if (!itemsLookup.ContainsKey(itemName))
+            {
+                itemsLookup.Add(itemName, foundItem);
+                Debug.Log($"Item '{itemName}' found in the scene and added to the lookup table.");
+            }
+            else
+            {
+                Debug.Log($"Item '{itemName}' is already in the lookup table.");
+            }
+        }
+        else
+        {
+            Debug.LogError($"Item '{itemName}' not found in the scene.");
+        }
+    }
+
+    public void SetInitialItem(string itemName, Vector3 position)
+    {
+        if (itemsLookup.TryGetValue(itemName, out GameObject itemPrefab))
+        {
+            currentItem = Instantiate(itemPrefab, position, Quaternion.identity);
+        }
+        else
+        {
+            Debug.LogError($"Item '{itemName}' not found in the lookup table.");
+        }
+    }
+
+    // Helper methods for testing in Start()
+    private void SwitchtoItem2()
+    {
+        ChangeItem("Item2");
+    }
+
+    private void SwitchtoItem3()
+    {
+        ChangeItem("Item3");
+    }
+}

--- a/Assets/Scripts/Managers/ItemManager.cs.meta
+++ b/Assets/Scripts/Managers/ItemManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf3e880fc785b244d909f661a2acdafa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - NPC
   - Object
   - Objective
+  - Stations
   layers:
   - Default
   - TransparentFX
@@ -18,7 +19,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - Stations
   - 
   - 
   - 


### PR DESCRIPTION
==========
 Changelog
==========
- Created new scene, "TestScene-ChangeObjects" to test object changes
- New script called "ItemManager" which changes the state of an item to something else. Currently just transforms the item.
- Either initialize the object to change as an object in the scene using FindInitialItem or grab one from the list with SetInitialItem. Then use ChangeItem to change your item to something in the list of items.
- Added new tag called "Stations" for the new script.
- Uses a dictionary as a lookup table.
- New cube prefabs for testing different objects to change state.
- Provides a setup for score later down the line.